### PR TITLE
Do not crash when log called on a background thread

### DIFF
--- a/app/src/main/java/com/hannesdorfmann/debugoverlay/sample/MainActivity.java
+++ b/app/src/main/java/com/hannesdorfmann/debugoverlay/sample/MainActivity.java
@@ -2,6 +2,7 @@ package com.hannesdorfmann.debugoverlay.sample;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -9,6 +10,8 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.widget.Switch;
+
 import com.hannesdorfmann.debugoverlay.DebugOverlay;
 
 public class MainActivity extends AppCompatActivity {
@@ -22,15 +25,25 @@ public class MainActivity extends AppCompatActivity {
     Toolbar toolbar = findViewById(R.id.toolbar);
     setSupportActionBar(toolbar);
 
+    Switch threadSwitch = findViewById(R.id.thread_switch);
     FloatingActionButton fab = findViewById(R.id.fab);
     fab.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View view) {
         boolean showDebugOverlay = Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.canDrawOverlays(MainActivity.this);
         if (showDebugOverlay) {
-          DebugOverlay.with(MainActivity.this).log("Message test " + i++);
+          final boolean inForeground = threadSwitch.isChecked();
+          if (inForeground) {
+            logMessage();
+          } else {
+            AsyncTask.execute(this::logMessage);
+          }
         } else {
           requestOverlayPermission();
         }
+      }
+
+      private void logMessage() {
+        DebugOverlay.with(MainActivity.this).log("Message test " + i++);
       }
     });
   }

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -13,8 +13,10 @@
     tools:showIn="@layout/activity_main"
     tools:context=".MainActivity">
 
-  <TextView
-      android:text="Hello World!"
+  <Switch
+      android:checked="true"
+      android:id="@+id/thread_switch"
+      android:text="Foreground thread"
       android:layout_width="wrap_content"
-      android:layout_height="wrap_content"/>
+      android:layout_height="wrap_content" />
 </RelativeLayout>

--- a/overlay/src/main/java/com/hannesdorfmann/debugoverlay/DebugOverlayService.java
+++ b/overlay/src/main/java/com/hannesdorfmann/debugoverlay/DebugOverlayService.java
@@ -3,6 +3,7 @@ package com.hannesdorfmann.debugoverlay;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Handler;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.view.View;
@@ -42,7 +43,11 @@ public class DebugOverlayService extends Service {
       });
     }
 
-    view.addMessage(msg);
+    runOnUiThread(() -> view.addMessage(msg));
+  }
+
+  private void runOnUiThread(Runnable runnable) {
+    new Handler(getMainLooper()).post(runnable);
   }
 
   @Override public void onDestroy() {


### PR DESCRIPTION
When `DebugOverlay.with(this).log("Message");` is called on a background thread, `CalledFromWrongThreadException` occur with the following stack trace:

```
android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
                                                                                            at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:7286)
                                                                                            at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:1155)
                                                                                            at android.view.View.requestLayout(View.java:21926)
                                                                                            at android.view.View.requestLayout(View.java:21926)
                                                                                            at android.widget.AbsListView.requestLayout(AbsListView.java:1998)
                                                                                            at android.widget.AdapterView$AdapterDataSetObserver.onChanged(AdapterView.java:848)
                                                                                            at android.widget.AbsListView$AdapterDataSetObserver.onChanged(AbsListView.java:6414)
                                                                                            at android.database.DataSetObservable.notifyChanged(DataSetObservable.java:37)
                                                                                            at android.widget.BaseAdapter.notifyDataSetChanged(BaseAdapter.java:50)
                                                                                            at com.hannesdorfmann.debugoverlay.DebugOverlayView.addMessage(DebugOverlayView.java:90)
                                                                                            at com.hannesdorfmann.debugoverlay.DebugOverlayService.logMsg(DebugOverlayService.java:45)
                                                                                            at com.hannesdorfmann.debugoverlay.DebugOverlay$MessageDispatcher.dispatch(DebugOverlay.java:118)
                                                                                            at com.hannesdorfmann.debugoverlay.DebugOverlay$MessageDispatcher.enqueueMessage(DebugOverlay.java:101)
                                                                                            at com.hannesdorfmann.debugoverlay.DebugOverlay.log(DebugOverlay.java:54)
```

To reproduce it, please checkout 898d23f commit from this pull request, set _Foregroung thread_ switch to false and press fab more than once.

Commit cf66434 fixes this issue by invoking `view.addMessage(msg)` on the UI thread.